### PR TITLE
Rewrite field names to camel-case in `struct` to `interface` conversion

### DIFF
--- a/camo-typescript/src/ast.rs
+++ b/camo-typescript/src/ast.rs
@@ -67,10 +67,26 @@ impl Field {
 impl From<camo::Field> for Field {
     fn from(field: camo::Field) -> Self {
         Self {
-            name: field.name,
+            name: snake_to_camel_case(&field.name),
             ty: Type::from(field.ty),
         }
     }
+}
+
+fn snake_to_camel_case(field: &str) -> String {
+    let mut result = String::new();
+    let mut capitalize = false;
+    for ch in field.chars() {
+        if ch == '_' {
+            capitalize = true;
+        } else if capitalize {
+            result.push(ch.to_ascii_uppercase());
+            capitalize = false;
+        } else {
+            result.push(ch);
+        }
+    }
+    result
 }
 
 impl fmt::Display for Field {

--- a/camo-typescript/tests/integration_tests.rs
+++ b/camo-typescript/tests/integration_tests.rs
@@ -107,3 +107,25 @@ fn works_with_export() {
             .field(Field::new("bar", Type::Builtin(Builtin::Boolean)))
     );
 }
+
+#[test]
+fn rewrites_to_camel_case() {
+    use camo_derive::Camo;
+
+    #[derive(Camo)]
+    struct Foo {
+        #[allow(unused)]
+        field_foo: u32,
+        #[allow(unused)]
+        field_foo_bar: bool,
+    }
+
+    let foo: Interface = Foo::camo().into();
+
+    assert_eq!(
+        foo,
+        Interface::new("Foo")
+            .field(Field::new("fieldFoo", Type::Builtin(Builtin::Number)))
+            .field(Field::new("fieldFooBar", Type::Builtin(Builtin::Boolean)))
+    );
+}


### PR DESCRIPTION
Resolves #18

Does not implement an option to turn off the conversion, though users can still work around it by not calling `.into()`.